### PR TITLE
[fix] 검색 기능 - 카카오 키워드로 검색 api 쿼리 변경

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="11" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="DesignSurface">
     <option name="filePathToZoomLevelMap">
@@ -138,5 +139,5 @@
     </option>
   </component>
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="corretto-11" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK" />
 </project>

--- a/app/src/main/java/com/aviro/android/data/api/KakaoService.kt
+++ b/app/src/main/java/com/aviro/android/data/api/KakaoService.kt
@@ -1,6 +1,5 @@
 package com.aviro.android.data.api
 
-
 import com.aviro.android.data.model.restaurant.SearchedListFromKakaoResponse
 import com.aviro.android.data.model.kakao.address.AddressOfCoordFromKakaoResponse
 import com.aviro.android.data.model.kakao.coordi.CoordOfAddressFromKakaoResponse
@@ -14,16 +13,18 @@ interface KakaoService {
         @Query("query") query : String,
         @Query("x") x : String?,
         @Query("y") y : String?,
-        @Query("category_group_code") category_group_code : String, // FD6=음식점 / CE7=카페
+        @Query("category_\\group_\\code") category_group_code : String, // FD6=음식점 / CE7=카페
         @Query("page") page : Int,
         @Query("size") size : Int,   //한 페이지에 보여질 문서의 개수
         @Query("sort") sort : String
     ) : Result<SearchedListFromKakaoResponse>
 
+
     @GET("search/address.json")
     suspend fun getCoordination(
         @Query("query") query : String,
     ) : Result<CoordOfAddressFromKakaoResponse>
+
 
     @GET("geo/coord2address.json")
     suspend fun getRoadAddress(


### PR DESCRIPTION
Descriptoin
1. 검색 기능 오류 해결 - 카카오 > 로컬 > 키워드로 검색  API 사용시, 쿼리문 변경에 대응해 해결